### PR TITLE
XplatUIX11: Fixed arithmetic overflow when processing keystrokes with…

### DIFF
--- a/System.Windows.Forms/System.Windows.Forms.CarbonInternal/MouseHandler.cs
+++ b/System.Windows.Forms/System.Windows.Forms.CarbonInternal/MouseHandler.cs
@@ -53,6 +53,15 @@ namespace System.Windows.Forms.CarbonInternal {
 		internal const uint DoubleClickInterval = 7500000;
 		internal static ClickStruct ClickPending;
 		
+		internal struct ClickStruct {
+			internal IntPtr	Hwnd;				// 
+			internal Msg	Message;			// 
+			internal IntPtr	wParam;				// 
+			internal IntPtr	lParam;				// 
+			internal long	Time;				// Last time we received a mouse click
+			internal bool	Pending;			// True if we haven't sent the last mouse click
+		}
+		
 		internal MouseHandler (XplatUICarbon driver) : base (driver) {}
 
 		public bool ProcessEvent (IntPtr callref, IntPtr eventref, IntPtr handle, uint kind, ref MSG msg) {

--- a/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
+++ b/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
@@ -309,7 +309,7 @@ namespace System.Windows.Forms {
 			if ((xevent.KeyEvent.keycode >> 8) == 0x10)
 				xevent.KeyEvent.keycode = xevent.KeyEvent.keycode & 0xFF;
 
-			int event_time = (int)xevent.KeyEvent.time;
+			uint event_time = (uint)xevent.KeyEvent.time;
 
 			if (status == XLookupStatus.XLookupChars) {
 				// do not ignore those inputs. They are mostly from XIM.
@@ -553,7 +553,7 @@ namespace System.Windows.Forms {
 			return msg;
 		}
 
-		private MSG SendKeyboardInput (VirtualKeys vkey, int scan, int keycode, KeybdEventFlags dw_flags, int time)
+		private MSG SendKeyboardInput (VirtualKeys vkey, int scan, int keycode, KeybdEventFlags dw_flags, uint time)
 		{
 			Msg message;
 
@@ -620,7 +620,7 @@ namespace System.Windows.Forms {
 			return (IntPtr)lparam;
 		}
 
-		private void GenerateMessage (VirtualKeys vkey, int scan, int key_code, XEventName type, int event_time)
+		private void GenerateMessage (VirtualKeys vkey, int scan, int key_code, XEventName type, uint event_time)
 		{
 			bool state = (vkey == VirtualKeys.VK_NUMLOCK ? num_state : cap_state);
 			KeybdEventFlags up, down;

--- a/System.Windows.Forms/System.Windows.Forms/X11Structs.cs
+++ b/System.Windows.Forms/System.Windows.Forms/X11Structs.cs
@@ -59,7 +59,7 @@ namespace System.Windows.Forms {
 		internal IntPtr		window;
 		internal IntPtr		root;
 		internal IntPtr		subwindow;
-		internal IntPtr		time;
+		internal UIntPtr		time;
 		internal int		x;
 		internal int		y;
 		internal int		x_root;
@@ -78,7 +78,7 @@ namespace System.Windows.Forms {
 		internal IntPtr		window;
 		internal IntPtr		root;
 		internal IntPtr		subwindow;
-		internal IntPtr		time;
+		internal UIntPtr		time;
 		internal int		x;
 		internal int		y;
 		internal int		x_root;
@@ -97,7 +97,7 @@ namespace System.Windows.Forms {
 		internal IntPtr		window;
 		internal IntPtr		root;
 		internal IntPtr		subwindow;
-		internal IntPtr		time;
+		internal UIntPtr		time;
 		internal int		x;
 		internal int		y;
 		internal int		x_root;
@@ -116,7 +116,7 @@ namespace System.Windows.Forms {
 		internal IntPtr		window;
 		internal IntPtr		root;
 		internal IntPtr		subwindow;
-		internal IntPtr		time;
+		internal UIntPtr		time;
 		internal int		x;
 		internal int		y;
 		internal int		x_root;
@@ -391,7 +391,7 @@ namespace System.Windows.Forms {
 		internal IntPtr		display;
 		internal IntPtr		window;
 		internal IntPtr		atom;
-		internal IntPtr		time;
+		internal UIntPtr		time;
 		internal int		state;
 	}
 
@@ -403,7 +403,7 @@ namespace System.Windows.Forms {
 		internal IntPtr		display;
 		internal IntPtr		window;
 		internal IntPtr		selection;
-		internal IntPtr		time;
+		internal UIntPtr		time;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
@@ -417,7 +417,7 @@ namespace System.Windows.Forms {
 		internal IntPtr		selection;
 		internal IntPtr		target;
 		internal IntPtr		property;
-		internal IntPtr		time;
+		internal UIntPtr		time;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
@@ -430,7 +430,7 @@ namespace System.Windows.Forms {
 		internal IntPtr		selection;
 		internal IntPtr		target;
 		internal IntPtr		property;
-		internal IntPtr		time;
+		internal UIntPtr		time;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
@@ -1483,7 +1483,7 @@ namespace System.Windows.Forms {
 		internal Msg	Message;			// 
 		internal IntPtr	wParam;				// 
 		internal IntPtr	lParam;				// 
-		internal long	Time;				// Last time we received a mouse click
+		internal uint	Time;				// Last time we received a mouse click
 		internal bool	Pending;			// True if we haven't sent the last mouse click
 	}
 

--- a/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -4169,7 +4169,7 @@ namespace System.Windows.Forms {
 						msg.hwnd = Grab.Hwnd;
 					}
 
-					if (ClickPending.Pending && ((((long)xevent.ButtonEvent.time - ClickPending.Time) < DoubleClickInterval) && (msg.wParam == ClickPending.wParam) && (msg.lParam == ClickPending.lParam) && (msg.message == ClickPending.Message))) {
+					if (ClickPending.Pending && (( unchecked((uint)xevent.ButtonEvent.time - ClickPending.Time) < DoubleClickInterval) && (msg.wParam == ClickPending.wParam) && (msg.lParam == ClickPending.lParam) && (msg.message == ClickPending.Message))) {
 						// Looks like a genuine double click, clicked twice on the same spot with the same keys
 						switch(xevent.ButtonEvent.button) {
 							case 1: {
@@ -4194,7 +4194,7 @@ namespace System.Windows.Forms {
 						ClickPending.Message = msg.message;
 						ClickPending.wParam = msg.wParam;
 						ClickPending.lParam = msg.lParam;
-						ClickPending.Time = (long)xevent.ButtonEvent.time;
+						ClickPending.Time = (uint)xevent.ButtonEvent.time;
 					}
 					
 					if (msg.message == Msg.WM_LBUTTONDOWN || msg.message == Msg.WM_MBUTTONDOWN || msg.message == Msg.WM_RBUTTONDOWN) {


### PR DESCRIPTION
… uptime of more than 25 days

In XKeyEvent, the time field is filled in with the time in milliseconds from the moment the X server is started. This value has a 32-bit unsigned integer data type, and when processed in managed code , it is converted to a 32-bit integer. This value is reset to 0 every 49.1 days and starts over. An overflow will occur if the X server runs for more than 24 days without restarting and the user presses a key in the WinForms application.

The original ClickStruct structure has been copied to the System.Windows.Forms.CarbonInternal/MouseHandler.cs because Mac uses DateTime.Now.Ticks to fill it, which is of type Int64