### PR TITLE
XplatUIX11: Fixed #5 double free or corruption (out)

### DIFF
--- a/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -4635,12 +4635,8 @@ namespace System.Windows.Forms {
 							    hwnd.client_window.ToInt32(), xevent.ExposeEvent.x, xevent.ExposeEvent.y,
 							    xevent.ExposeEvent.width, xevent.ExposeEvent.height);
 
-						Rectangle rect = new Rectangle (xevent.ExposeEvent.x, xevent.ExposeEvent.y, xevent.ExposeEvent.width, xevent.ExposeEvent.height);
-						Region region = new Region (rect);
-						IntPtr hrgn = region.GetHrgn (Graphics.FromHwnd(hwnd.whole_window)); // Graphics object isn't needed
 						msg.message = Msg.WM_NCPAINT;
-						msg.wParam = hrgn == IntPtr.Zero ? (IntPtr)1 : hrgn;
-						msg.refobject = region;
+						msg.wParam = (IntPtr)1;
 						break;
 					}
 					DriverDebug("GetMessage(): Window {0:X} Exposed area {1},{2} {3}x{4}",


### PR DESCRIPTION
Fixed the native error double free or corruption (out) #5

The error occurred due to a chain of calls
to region.GetHrgn (Graphics.FromHwnd(hwnd.whole_window)). Probably a Graphics object obtained from Graphics.FromHwnd could be released later or earlier than the Hwnd from which it was created. In mono, this code looks like region.GetHrgn (null); In the System.Drawing in mono returns null when passing NativeObject, and in System.Drawing.Common is thrown away ArgumentNullException. I tried not to create anything, but to transfer it to wParam (IntPtr)1. There were no problems during the checks.