### PR TITLE
XplatUIX11: fixed a handles leak

### DIFF
--- a/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -4018,7 +4018,7 @@ namespace System.Windows.Forms {
 			// hwnds, since much of the event handling code makes requests using the hwnd's
 			// client_window, and that'll result in BadWindow errors if there's some lag
 			// between the XDestroyWindow call and the DestroyNotify event.
-			if (hwnd == null || hwnd.zombie && xevent.AnyEvent.type != XEventName.ClientMessage) {
+			if (hwnd == null || hwnd.zombie && xevent.AnyEvent.type != XEventName.ClientMessage && xevent.type != XEventName.DestroyNotify) {
 				DriverDebug("GetMessage(): Got message {0} for non-existent or already destroyed window {1:X}", xevent.type, xevent.AnyEvent.window.ToInt32());
 				goto ProcessNextMessage;
 			}


### PR DESCRIPTION
According to https://github.com/mono/mono/issues/20769 an DestroyNotify event, which was supposed to delete handles from Hwnd.windows, was skipped and Dispose was supposed to be called for them. Due to the fact that they remained in the Hwnd.windows collection, and in X11 these handles were already considered free , X11 could issue a handle number that is already in Hwnd.windows.