### PR TITLE
XplatUIX11: Fixed memory leak in xic_table

### DIFF
--- a/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -3583,7 +3583,7 @@ namespace System.Windows.Forms {
 			lock (XlibLock) {
 				if (hwnd.whole_window != IntPtr.Zero) {
 					DriverDebug ("XDestroyWindow (whole_window = {0:X})", hwnd.whole_window.ToInt32());
-					Keyboard.DestroyICForWindow (hwnd.whole_window);
+					Keyboard.DestroyICForWindow (hwnd.client_window);
 					XDestroyWindow(DisplayHandle, hwnd.whole_window);
 				}
 				else if (hwnd.client_window != IntPtr.Zero) {


### PR DESCRIPTION
Fixed memory leak in xic_table

The entry in xic_table was created using the hwnd.client_window key, and they try to do the removal by hwnd.whole_window.