### PR TITLE
XplatUIX11: Use default cursor bitmap if XQueryBestCursor returns zero width

### DIFF
--- a/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -2791,7 +2791,7 @@ namespace System.Windows.Forms {
 			}
 
 			// Win32 only allows creation cursors of a certain size
-			if ((bitmap.Width != width) || (bitmap.Width != height)) {
+			if (width != 0 && height != 0 && (bitmap.Width != width || bitmap.Width != height)) {
 				cursor_bitmap = new Bitmap(bitmap, new Size(width, height));
 				cursor_mask = new Bitmap(mask, new Size(width, height));
 			} else {


### PR DESCRIPTION
Use default cursor bitmap with nonzero width and height if XQueryBestCursor returns zero width and height