### PR TITLE
XplatUIX11: Check for null Control.FromHandle result before access to…

### DIFF
--- a/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -5758,8 +5758,11 @@ namespace System.Windows.Forms {
 
 				lock (XlibLock) {
 					Control ctrl = Control.FromHandle (handle);
-					Size TranslatedSize = TranslateWindowSizeToXWindowSize (ctrl.GetCreateParams (), new Size (width, height));
-					MoveResizeWindow (DisplayHandle, hwnd.whole_window, x, y, TranslatedSize.Width, TranslatedSize.Height);
+					if (ctrl != null)
+					{
+						Size TranslatedSize = TranslateWindowSizeToXWindowSize (ctrl.GetCreateParams (), new Size (width, height));
+						MoveResizeWindow (DisplayHandle, hwnd.whole_window, x, y, TranslatedSize.Width, TranslatedSize.Height);
+					}
 					PerformNCCalc(hwnd);
 				}
 			}


### PR DESCRIPTION
… control in SetWindowPos

Control can be destroyed before handle destroy, so check it for null as in other places do.