### PR TITLE
Implemented replacement of the DllMap with AssemblyResolver

### DIFF
--- a/System.Windows.Forms/Assembly/LibraryResolver.cs
+++ b/System.Windows.Forms/Assembly/LibraryResolver.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace System.Windows.Forms;
+
+internal class LibraryResolver
+{
+    static LibraryResolver()
+    {
+        NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), DllImportResolver);
+    }
+    
+    private static readonly Dictionary<string, string> DllMap = new()
+    {
+        { "libX11", "libX11.so.6" },
+        { "libXcursor", "libXcursor.so.1" },
+        { "libglib-2.0.so", "libglib-2.0.so.0" },
+        { "libgobject-2.0.so", "libgobject-2.0.so.0" },
+        { "libgobject-2.0", "libgobject-2.0.so.0" },
+        { "libgdk-x11-2.0.so", "libgdk-x11-2.0.so.0" },
+        { "libgdk-x11-2.0", "libgdk-x11-2.0.so.0" },
+        { "libgtk-x11-2.0.so", "libgtk-x11-2.0.so.0" },
+        { "libgtk-x11-2.0", "libgtk-x11-2.0.so.0" },
+        { "libgdk_pixbuf-2.0.so", "libgdk_pixbuf-2.0.so.0" },
+        { "libgdk_pixbuf-2.0", "libgdk_pixbuf-2.0.so.0" }
+    };
+
+    private static IntPtr DllImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+    {
+        if (NativeLibrary.TryLoad(libraryName, assembly, searchPath, out var handle))
+            return handle;
+        if (DllMap.TryGetValue(libraryName, out var value))
+            return NativeLibrary.TryLoad(value, assembly, searchPath, out handle) ? handle : IntPtr.Zero;
+        return IntPtr.Zero;
+    }
+
+    internal static void EnsureRegistered()
+    {
+        
+    }
+}

--- a/System.Windows.Forms/System.Windows.Forms/XplatUI.cs
+++ b/System.Windows.Forms/System.Windows.Forms/XplatUI.cs
@@ -91,6 +91,7 @@ namespace System.Windows.Forms {
 			// and name must be unique to process. If we load MWF into multiple appdomains
 			// and try to register same class name we fail.
 //			default_class_name = "SWFClass" + System.Threading.Thread.GetDomainID ().ToString ();
+			LibraryResolver.EnsureRegistered();
 
 			if (RunningOnUnix) {
 				//if (Environment.GetEnvironmentVariable ("not_supported_MONO_MWF_USE_NEW_X11_BACKEND") != null) {


### PR DESCRIPTION
In my distro Winforms application cannot find libX11 at startup. In mono, DllMap searches for libraries. dotnet is suggested to use AssemblyResolver instead.