### PR TITLE
System.Windows.Forms: Clear cached selection in X11Clipboard.Clear.

### DIFF
--- a/System.Windows.Forms/System.Windows.Forms/X11Clipboard.cs
+++ b/System.Windows.Forms/System.Windows.Forms/X11Clipboard.cs
@@ -135,6 +135,7 @@ namespace System.Windows.Forms {
 
 		internal void Clear () {
 			XplatUIX11.XSetSelectionOwner (XplatUIX11.Display, Selection, IntPtr.Zero, UIntPtr.Zero);
+			ClearOwnSelection ();
 		}
 
 		internal IDataObject GetContent () {

--- a/System.Windows.Forms/System.Windows.Forms/X11Selection.cs
+++ b/System.Windows.Forms/System.Windows.Forms/X11Selection.cs
@@ -167,9 +167,13 @@ namespace System.Windows.Forms {
 			}
 		}
 
-		internal virtual void HandleSelectionClearEvent (ref XEvent xevent) {
+		internal void ClearOwnSelection () {
 			Outgoing = null;
 			X11SelectionHandler.FreeNativeSelectionBuffers(Selection);
+		}
+
+		internal virtual void HandleSelectionClearEvent (ref XEvent xevent) {
+			ClearOwnSelection ();
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/DanielVanNoord/System.Windows.Forms/issues/17