### PR TITLE
Make OK button in PrintDialog enabled

### DIFF
--- a/System.Windows.Forms/System.Windows.Forms/PrintDialog.cs
+++ b/System.Windows.Forms/System.Windows.Forms/PrintDialog.cs
@@ -594,7 +594,7 @@ namespace System.Windows.Forms
 			{
 				string printer, port = string.Empty, type = string.Empty;
 				string status = string.Empty, comment = string.Empty;
-				Type sysprn = Type.GetType ("System.Drawing.Printing.SysPrn, System.Drawing");
+				Type sysprn = Type.GetType ("System.Drawing.Printing.SysPrn, System.Drawing.Common");
 				MethodInfo dlg_info = sysprn.GetMethod ("GetPrintDialogInfo", BindingFlags.Static | BindingFlags.NonPublic);
 
 				printer = (string) printer_combo.SelectedItem;


### PR DESCRIPTION
After move from System.Drawing to System.Drawing.Common this part which uses reflection wasn't retargeted.