### PR TITLE
XplatUIX11: Check for null Hwnd.ObjectFromHandle result before access

### DIFF
--- a/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
+++ b/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
@@ -1182,7 +1182,7 @@ namespace System.Windows.Forms {
 			if (control == null || !control.IsHandleCreated)
 				return;
 			Hwnd hwnd = Hwnd.ObjectFromHandle (client_window);
-			if (!hwnd.mapped)
+			if (hwnd == null || !hwnd.mapped)
 				return;
 
 			int dx, dy;


### PR DESCRIPTION
Hwnd can be destroyed before handle destroy, so check it for null as in other places do.