### PR TITLE
Accelerated the ListView.EnsureVisible() method on virtual lists

### DIFF
--- a/System.Windows.Forms/System.Windows.Forms/ListView.cs
+++ b/System.Windows.Forms/System.Windows.Forms/ListView.cs
@@ -5308,13 +5308,8 @@ namespace System.Windows.Forms
 
 			public int IndexOf (ListViewItem item)
 			{
-				if (owner != null && owner.VirtualMode) {
-					for (int i = 0; i < Count; i++)
-						if (RetrieveVirtualItemFromOwner (i) == item)
-							return i;
-
-					return -1;
-				}
+				if (owner != null && owner.VirtualMode)
+					return item.Index;
 				
 				return list.IndexOf (item);
 			}


### PR DESCRIPTION
The ListView.EnsureVisible() method took a very long time to run on large lists because it called OnRetriveVirtualItem for each element, pulling the entire list