### PR TITLE
ToolStrip: Do not capture mouse when processing a click

### DIFF
--- a/System.Windows.Forms/System.Windows.Forms/ToolStrip.cs
+++ b/System.Windows.Forms/System.Windows.Forms/ToolStrip.cs
@@ -969,9 +969,11 @@ namespace System.Windows.Forms
 			// If we're currently over an item (set in MouseMove)
 			if (mouse_currently_over != null && !(mouse_currently_over is ToolStripControlHost) && mouse_currently_over.Enabled) {
 				// Fire our ItemClicked event, but only for a left mouse click.
-				if (mea.Button == MouseButtons.Left)
+				if (Capture && mea.Button == MouseButtons.Left) {
+					Capture = false;
 					OnItemClicked (new ToolStripItemClickedEventArgs (mouse_currently_over));
-					
+				}
+
 				// Fire the item's MouseUp event
 				if (mouse_currently_over != null)
 					mouse_currently_over.FireEvent (mea, ToolStripItemEventType.MouseUp);


### PR DESCRIPTION
If you put a debugger in the toolbar button click handler, the mouse buttons will be captured by the toolbar and will not be processed by other applications.