### PR TITLE
winforms: Call XCreateFontSet only once.

### DIFF
--- a/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
+++ b/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
@@ -71,6 +71,7 @@ namespace System.Windows.Forms {
 		private bool initialized;
 		private bool menu_state = false;
 		private Encoding encoding;
+		private IntPtr fontSet;
 
 		private int NumLockMask;
 		private int AltGrMask;
@@ -80,6 +81,7 @@ namespace System.Windows.Forms {
 			this.display = display;
 			lookup_buffer = new StringBuilder (24);
 			EnsureLayoutInitialized ();
+			SetupFontSet ();
 		}
 
 		private Encoding AnsiEncoding
@@ -153,6 +155,14 @@ namespace System.Windows.Forms {
 				Console.Error.WriteLine ("Could not get XIM");
 
 			initialized = true;
+		}
+
+		private void SetupFontSet ()
+		{
+			IntPtr list;
+			int count;
+			fontSet = XCreateFontSet (display, "fixed", out list, out count, IntPtr.Zero);
+			XFreeStringList (list);
 		}
 
 		void CreateXicForWindow (IntPtr window)
@@ -1013,11 +1023,7 @@ namespace System.Windows.Forms {
 
 		private IntPtr CreateOverTheSpotXic (IntPtr window, IntPtr xim)
 		{
-			IntPtr list;
-			int count;
 			Control c = Control.FromHandle (window);
-			string xlfd = String.Format ("-*-*-*-*-*-*-{0}-*-*-*-*-*-*-*", (int) c.Font.Size);
-			IntPtr fontSet = XCreateFontSet (display, xlfd, out list, out count, IntPtr.Zero);
 			XPoint spot = new XPoint ();
 			spot.X = 0;
 			spot.Y = 0;
@@ -1039,7 +1045,6 @@ namespace System.Windows.Forms {
 					Marshal.FreeHGlobal (pSL);
 				if (pFS != IntPtr.Zero)
 					Marshal.FreeHGlobal (pFS);
-				XFreeStringList (list);
 				//XplatUIX11.XFree (preedit);
 				//XFreeFontSet (fontSet);
 			}


### PR DESCRIPTION
See https://gitlab.winehq.org/mono/mono/-/issues/10

XCreateFontSet appears to be thread-unsafe (I filed a bug with libX11), and it was causing crashes with multi-threaded winforms use.