### PR TITLE
Revert "Clean up the selected node to prevent exceptions in Dispose"

### DIFF
--- a/System.Windows.Forms/System.Windows.Forms/TreeNodeCollection.cs
+++ b/System.Windows.Forms/System.Windows.Forms/TreeNodeCollection.cs
@@ -197,15 +197,13 @@ namespace System.Windows.Forms {
 
 		public virtual void Clear ()
 		{
-			TreeView tree_view = TreeView;
-			if (tree_view != null)
-				tree_view.SelectedNode = null;
 			while (count > 0)
 				RemoveAt (0, false);
 			
 			Array.Clear (nodes, 0, count);
 			count = 0;
 
+			TreeView tree_view = TreeView;
 			if (tree_view != null) {
 				tree_view.UpdateBelow (owner);
 				tree_view.RecalculateVisibleOrder (owner);


### PR DESCRIPTION
Reverts DanielVanNoord/System.Windows.Forms#22

You don't need to clear the selected node, as this happens in RemoveAt